### PR TITLE
Align imageRepository variable with documentation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ stages:
       displayName: Build and push an image to container registry
       inputs:
         command: buildAndPush
-        repository: captureorder
+        repository: $(imageRepository)
         dockerfile: '**/Dockerfile'
         containerRegistry: $(dockerRegistryServiceConnection)
         tags: $(tag)


### PR DESCRIPTION
The documentation in section 3.1 of https://aksworkshop.io indicates the repository should be the generic variable `$(imageRepository)`, but in this repository it's hardcoded as `captureorder`

![image](https://user-images.githubusercontent.com/5757382/69157517-abb97e80-0aaa-11ea-959c-37249589820f.png)
